### PR TITLE
[BUGFIX] Use correct node for content collection metadata

### DIFF
--- a/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ContentCollection.ts2
+++ b/TYPO3.Neos/Resources/Private/TypoScript/Prototypes/ContentCollection.ts2
@@ -15,7 +15,7 @@ prototype(TYPO3.Neos:ContentCollection) < prototype(TYPO3.Neos:Content) {
 	@override.contentCollectionNode = ${Neos.Node.nearestContentCollection(node, this.nodePath)}
 
 	@process.contentElementWrapping {
-		node = ${contentCollectionNode}
+		expression.node = ${contentCollectionNode}
 	}
 
 	@cache {


### PR DESCRIPTION
Content collection handles are not shown since the meta data
added is using the document node instead of the actual node.

Regression introduced with 4672697b9477ceca53ee7b4e47c4def002e50e32
causing the node not to be set correctly for the
`contentElementWrapping` processor.

Related: NEOS-1326
