### PR TITLE
TASK: Add currentUserCanReadWorkspace to UserService

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Controller/Module/Management/AssetController.php
@@ -157,8 +157,8 @@ class AssetController extends \TYPO3\Media\Controller\AssetController
         $userWorkspace = $this->userService->getPersonalWorkspace();
         $relatedNodes = [];
         foreach ($this->getRelatedNodes($asset) as $relatedNodeData) {
-            $accessible = $this->domainUserService->currentUserCanPublishToWorkspace($relatedNodeData->getWorkspace());
-            if ($accessible && $relatedNodeData->getWorkspace()->getName() !== 'live') {
+            $accessible = $this->domainUserService->currentUserCanReadWorkspace($relatedNodeData->getWorkspace());
+            if ($accessible) {
                 $context = $this->createContextMatchingNodeData($relatedNodeData);
             } else {
                 $context = $this->createContentContext($userWorkspace->getName());

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/UserService.php
@@ -600,6 +600,28 @@ class UserService
     }
 
     /**
+     * Checks if the current user may read the given workspace according to one the roles of the user's accounts
+     *
+     * In future versions, this logic may be implemented in Neos in a more generic way (for example, by means of an
+     * ACL object), but for now, this method exists in order to at least centralize and encapsulate the required logic.
+     *
+     * @param Workspace $workspace The workspace
+     * @return boolean
+     */
+    public function currentUserCanReadWorkspace(Workspace $workspace)
+    {
+        if ($workspace->getName() === 'live') {
+            return true;
+        }
+
+        if ($workspace->getOwner() === $this->getCurrentUser() || $workspace->getOwner() === null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Checks if the current user may manage the given workspace according to one the roles of the user's accounts
      *
      * In future versions, this logic may be implemented in Neos in a more generic way (for example, by means of an


### PR DESCRIPTION
This change introduces currentUserCanReadWorkspace to the UserService
in Neos. This allows to determine if the user has read access instead
of using currentUserCanPublishToWorkspace to check if a link to the
workspace can be created.
